### PR TITLE
Add a Jackson serializer for the vets JSON endpoint

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/vet/VetSerializer.java
+++ b/src/main/java/org/springframework/samples/petclinic/vet/VetSerializer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.samples.petclinic.vet;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import org.springframework.boot.jackson.JsonComponent;
+
+/**
+ * Serializes a {@link Vet} for the JSON returned by {@link VetController}, listing each
+ * specialty by name rather than as a nested object.
+ *
+ * @author Arjen Poutsma
+ */
+@JsonComponent
+public class VetSerializer extends JsonSerializer<Vet> {
+
+    @Override
+    public void serialize(Vet vet, JsonGenerator generator, SerializerProvider serializers) throws IOException {
+        generator.writeStartObject();
+        generator.writeNumberField("id", vet.getId());
+        generator.writeStringField("firstName", vet.getFirstName());
+        generator.writeStringField("lastName", vet.getLastName());
+        generator.writeArrayFieldStart("specialties");
+        for (Specialty specialty : vet.getSpecialties()) {
+            generator.writeString(specialty.getName());
+        }
+        generator.writeEndArray();
+        generator.writeEndObject();
+    }
+
+}


### PR DESCRIPTION
`VetController` already serves `GET /vets` with `@ResponseBody`, so Jackson has always produced that payload — by reflection over `Vets.getVetList()`. Reflection emits each specialty as a nested object and picks up `getNrOfSpecialties()` and `isNew()`, so the response carries persistence bookkeeping no caller wants.

`VetSerializer` lists specialties by name and leaves the bookkeeping out. It registers through `@JsonComponent`, so the `Vet` entity is untouched.

It also gives this repository some Jackson usage in `src/main`, which it has never had. The OpenRewrite quickstart guide uses this repo as its sample project and its final step demonstrates running a recipe from an external module; the Jackson 2.x to 3.x migration was picked for that step and currently changes nothing here. With this class, running it rewrites three imports, the supertype, the method signature and four method calls, plus the `jackson-databind` coordinates in `pom.xml`.

Indentation is four spaces to match the rest of this branch. That matters more than it sounds: with tabs, OpenRewrite normalises the whole method to the branch's detected style and the real changes disappear into whitespace.

Note that running the Jackson migration to completion leaves the app unable to start, because Spring Boot 2.1's ASM cannot read Jackson 3's Java 17 class files. That is expected for a repo whose purpose is being deliberately outdated, and the quickstart only claims the recipe makes the changes, not that the result runs.
